### PR TITLE
Small changes for ease-of-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ npm run build
 ```
 Which will compile angular and bundle it with the appropriate Java files.
 
+## Deploying the application to AppEngine
+To deploy to AppEngine, please run
+```
+npm run deploy
+```
+
 ## Licensing
 A special thanks to the authors of these libraries:
 - angular-google-charts - [MIT](https://github.com/FERNman/angular-google-charts/blob/master/LICENSE.md)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "recommendations-impact-dashboard",
   "scripts": {
     "test": "ts-node node_modules/jasmine/bin/jasmine src/**/*.spec.ts",
-    "build": "ng build && cp -r src/main/angular/WEB-INF src/main/webapp/WEB-INF && mvn package appengine:run",
+    "build": "ng build && cp -r src/main/angular/WEB-INF src/main/webapp/WEB-INF && mvn package appengine:run -DskipTests",
+    "deploy": "ng build && cp -r src/main/angular/WEB-INF src/main/webapp/WEB-INF && mvn package appengine:deploy -DskipTests",
     "serve": "ng serve --open",
     "check": "gts check src/**/*.ts",
     "clean": "gts clean",

--- a/pom.xml
+++ b/pom.xml
@@ -108,8 +108,7 @@
         <artifactId>appengine-maven-plugin</artifactId>
         <version>2.2.0</version>
         <configuration>
-          <!-- TODO: set project ID. -->
-          <deploy.projectId>PROJECT_ID_HERE</deploy.projectId>
+          <deploy.projectId>concord-intern</deploy.projectId>
           <deploy.version>1</deploy.version>
           <port>8080</port>
         </configuration>

--- a/src/main/angular/WEB-INF/web.xml
+++ b/src/main/angular/WEB-INF/web.xml
@@ -1,14 +1,10 @@
-<web-app>
-    <servlet>
-        <servlet-name>ErrorHandler</servlet-name>
-        <servlet-class>com.google.impactDashboard.servlets.ErrorHandlerServlet</servlet-class>
-    </servlet>
-    <servlet-mapping>
-        <servlet-name>ErrorHandler</servlet-name>
-        <url-pattern>/error-handler</url-pattern>
-    </servlet-mapping>
-    <error-page>
-        <exception-type>java.lang.RuntimeException</exception-type>
-        <location>/error-handler</location>
-    </error-page>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+        version="3.1">
+  <error-page>
+    <exception-type>java.lang.RuntimeException</exception-type>
+    <location>/error-handler</location>
+  </error-page>
 </web-app>

--- a/src/main/java/com/google/impactdashboard/data/project/ProjectGraphData.java
+++ b/src/main/java/com/google/impactdashboard/data/project/ProjectGraphData.java
@@ -9,8 +9,8 @@ import com.google.auto.value.AutoValue;
 public abstract class ProjectGraphData {
 
   public abstract String getProjectId();
-  public abstract Map<Long, Integer> getNumberIAMBindingsOnDate();
-  public abstract Map<Long, Recommendation> getRecommendationsAppliedOnDate();
+  public abstract Map<Long, Integer> getDateToNumberIAMBindings();
+  public abstract Map<Long, Recommendation> getDateToRecommendationTaken();
 
   /** 
    * Create an {@code ProjectGraphData} object for project {@code projectId}, where 


### PR DESCRIPTION
Small change to `ProjectGraphData` backend to follow the property names set out in design doc. 

Also adds `npm run deploy` which should deploy to AppEngine.