### PR TITLE
Make DatabaseAccessor Singleton

### DIFF
--- a/src/main/java/com/google/impactdashboard/database_manager/bigquery/DatabaseAccessor.java
+++ b/src/main/java/com/google/impactdashboard/database_manager/bigquery/DatabaseAccessor.java
@@ -10,26 +10,25 @@ import com.google.cloud.bigquery.TableResult;
 import java.util.UUID;
 import java.lang.RuntimeException;
 import java.lang.InterruptedException;
-import com.google.impactdashboard.configuration.Constants;
-import com.google.auth.oauth2.GoogleCredentials;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.ByteArrayInputStream;
 import com.google.impactdashboard.Credentials;
 
 /** A class that queries the database. */
 public class DatabaseAccessor {
 
   private BigQuery bigquery;
+  private static final DatabaseAccessor INSTANCE = new DatabaseAccessor();
+
+  public static DatabaseAccessor getInstance() {
+    return INSTANCE;
+  }
 
   /** 
    * Creates a {@code DatabaseAccesor} instance that contains an instance of 
-   * {@code BigQuery} as well as the correct database to be queried based on the 
-   * system configuration flags. 
+   * {@code BigQuery}.
    * @throws RuntimeException if the credentials to access the database cannot 
       be established.
    */
-  public DatabaseAccessor() {
+  private DatabaseAccessor() {
       bigquery = BigQueryOptions.newBuilder()
       .setCredentials(Credentials.getCredentials()).build().getService();
   }

--- a/src/main/java/com/google/impactdashboard/database_manager/data_read/DataReadManagerImpl.java
+++ b/src/main/java/com/google/impactdashboard/database_manager/data_read/DataReadManagerImpl.java
@@ -21,7 +21,7 @@ public class DataReadManagerImpl implements DataReadManager {
   QueryConfigurationBuilder queryConfigurationBuilder;
 
   public DataReadManagerImpl() {
-    database = new DatabaseAccessor(); 
+    database = DatabaseAccessor.getInstance(); 
     queryConfigurationBuilder = QueryConfigurationBuilderFactory.create();
   }
   

--- a/src/main/java/com/google/impactdashboard/database_manager/data_update/DataUpdateManagerImpl.java
+++ b/src/main/java/com/google/impactdashboard/database_manager/data_update/DataUpdateManagerImpl.java
@@ -12,7 +12,7 @@ public class DataUpdateManagerImpl implements DataUpdateManager {
   QueryConfigurationBuilder queryConfigurationBuilder;
 
   public DataUpdateManagerImpl() {
-    database = new DatabaseAccessor(); 
+    database = DatabaseAccessor.getInstance(); 
     queryConfigurationBuilder = QueryConfigurationBuilderFactory.create();
   }
 


### PR DESCRIPTION
A very small change that prevents us from unnecessarily instantiating multiple Bigquery instances. 