### PR TITLE
Fix data retrieval failure

### DIFF
--- a/src/main/java/com/google/impactdashboard/configuration/Constants.java
+++ b/src/main/java/com/google/impactdashboard/configuration/Constants.java
@@ -8,7 +8,7 @@ public class Constants {
 
   /** The path to the service account key. */
   public static final String PATH_TO_SERVICE_ACCOUNT_KEY = 
-    "/usr/local/google/home/ionis/Downloads/key.json";
+    "/usr/local/google/home/carolinelui/Downloads/key.json";
 
   /** The name of the table holding recommendations data. */
   public static final String RECOMMENDATIONS_TABLE = "Recommendations";

--- a/src/main/java/com/google/impactdashboard/server/api_utilities/LogRetriever.java
+++ b/src/main/java/com/google/impactdashboard/server/api_utilities/LogRetriever.java
@@ -4,6 +4,7 @@ import com.google.cloud.logging.v2.LoggingClient;
 import com.google.cloud.logging.v2.LoggingClient.ListLogEntriesPagedResponse;
 import com.google.cloud.logging.v2.LoggingSettings;
 import com.google.cloud.logging.v2.stub.LoggingServiceV2StubSettings;
+import com.google.common.base.Strings;
 import com.google.impactdashboard.Credentials;
 import com.google.logging.v2.ListLogEntriesRequest;
 import java.io.IOException;
@@ -62,7 +63,7 @@ public class LogRetriever {
     ListLogEntriesRequest.Builder builder = ListLogEntriesRequest.newBuilder()
         .setOrderBy("timestamp desc").addResourceNames(resourceNameStringBuilder.toString());
 
-    if(!pageToken.equals("")) {
+    if(!Strings.isNullOrEmpty(pageToken)) {
       builder.setPageToken(pageToken);
     }
 

--- a/src/main/java/com/google/impactdashboard/server/api_utilities/LogRetriever.java
+++ b/src/main/java/com/google/impactdashboard/server/api_utilities/LogRetriever.java
@@ -62,7 +62,7 @@ public class LogRetriever {
     ListLogEntriesRequest.Builder builder = ListLogEntriesRequest.newBuilder()
         .setOrderBy("timestamp desc").addResourceNames(resourceNameStringBuilder.toString());
 
-    if(pageToken != null) {
+    if(pageToken != null && !pageToken.equals("")) {
       builder.setPageToken(pageToken);
     }
 

--- a/src/main/java/com/google/impactdashboard/server/api_utilities/LogRetriever.java
+++ b/src/main/java/com/google/impactdashboard/server/api_utilities/LogRetriever.java
@@ -62,7 +62,7 @@ public class LogRetriever {
     ListLogEntriesRequest.Builder builder = ListLogEntriesRequest.newBuilder()
         .setOrderBy("timestamp desc").addResourceNames(resourceNameStringBuilder.toString());
 
-    if(pageToken != null && !pageToken.equals("")) {
+    if(!pageToken.equals("")) {
       builder.setPageToken(pageToken);
     }
 

--- a/src/main/java/com/google/impactdashboard/server/data_update/DataUpdater.java
+++ b/src/main/java/com/google/impactdashboard/server/data_update/DataUpdater.java
@@ -4,6 +4,7 @@ import com.google.api.gax.rpc.PermissionDeniedException;
 import com.google.cloud.logging.v2.LoggingClient.ListLogEntriesPagedResponse;
 import com.google.cloud.logging.v2.LoggingClient;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.impactdashboard.data.IAMBindingDatabaseEntry;
 import com.google.impactdashboard.data.project.ProjectIdentification;
 import com.google.impactdashboard.data.recommendation.Recommendation;
@@ -147,7 +148,7 @@ public class DataUpdater {
             project.getProjectId(), "", timeTo, 1, pageToken);
         entry = response.getPage().getResponse().getEntriesList();
         pageToken = response.getNextPageToken();
-      } while (entry.isEmpty() && !pageToken.equals(""));
+      } while (entry.isEmpty() && !Strings.isNullOrEmpty(pageToken));
 
       List<IAMBindingDatabaseEntry> lastEntry = iamRetriever
           .listIAMBindingData(entry, project.getProjectId(), project.getName(),

--- a/src/main/java/com/google/impactdashboard/server/data_update/DataUpdater.java
+++ b/src/main/java/com/google/impactdashboard/server/data_update/DataUpdater.java
@@ -5,7 +5,6 @@ import com.google.cloud.logging.v2.LoggingClient.ListLogEntriesPagedResponse;
 import com.google.cloud.logging.v2.LoggingClient;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.impactdashboard.data.IAMBindingDatabaseEntry;
-import com.google.impactdashboard.data.organization.OrganizationIdentification;
 import com.google.impactdashboard.data.project.ProjectIdentification;
 import com.google.impactdashboard.data.recommendation.Recommendation;
 import com.google.impactdashboard.database_manager.data_read.DataReadManager;
@@ -16,7 +15,6 @@ import com.google.impactdashboard.server.api_utilities.ResourceRetriever;
 import com.google.impactdashboard.server.api_utilities.RecommendationRetriever;
 import com.google.logging.v2.LogEntry;
 
-import java.lang.reflect.Array;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -149,7 +147,7 @@ public class DataUpdater {
             project.getProjectId(), "", timeTo, 1, pageToken);
         entry = response.getPage().getResponse().getEntriesList();
         pageToken = response.getNextPageToken();
-      } while (entry.isEmpty() && pageToken != null);
+      } while (entry.isEmpty() && !pageToken.equals(""));
 
       List<IAMBindingDatabaseEntry> lastEntry = iamRetriever
           .listIAMBindingData(entry, project.getProjectId(), project.getName(),
@@ -159,11 +157,6 @@ public class DataUpdater {
     } catch (Exception e) {
       return new ArrayList<>();
     }
-  }
-
-  public static void main(String[] args) throws Exception {
-    AutomaticDataUpdater auto = AutomaticDataUpdater.create();
-    auto.getLastIamEntry(ProjectIdentification.create("davidgaskins-eg-codelab", "davidgaskins-eg-codelab", 0L), "");
   }
 
   /**

--- a/src/test/java/com/google/impactdashboard/server/data_update/DataUpdaterTest.java
+++ b/src/test/java/com/google/impactdashboard/server/data_update/DataUpdaterTest.java
@@ -196,13 +196,13 @@ public class DataUpdaterTest extends Mockito {
         Collections.singletonList(mock(LogEntry.class));
 
     when(mockLogRetriever.listAuditLogsResponse(eq(PROJECT_3.getProjectId()), anyString(),
-        anyString(), anyInt())).thenReturn(project3Response);
+        anyString(), anyInt(), anyString())).thenReturn(project3Response);
 
     when(mockLogRetriever.listAuditLogsResponse(eq(PROJECT_2.getProjectId()), anyString(),
-        anyString(), anyInt())).thenReturn(project2Response);
+        anyString(), anyInt(), anyString())).thenReturn(project2Response);
 
     when(mockLogRetriever.listAuditLogsResponse(eq(PROJECT_1.getProjectId()), anyString(),
-        anyString(), anyInt())).thenReturn(project1Response);
+        anyString(), anyInt(), anyString())).thenReturn(project1Response);
 
     when(project3Response.iterateAll()).thenReturn(project3AuditLogs);
 


### PR DESCRIPTION
We discovered that when the most recent log entry was a long time ago, Cloud Logging will retrieve it, but only after retrieving several empty pages. We added in a loop that checks each page until it finds something to fix this. 